### PR TITLE
Implementing configuration for AutoOffsetReset

### DIFF
--- a/Source/Otc.PubSub.Abstractions/Otc.PubSub.Abstractions.csproj
+++ b/Source/Otc.PubSub.Abstractions/Otc.PubSub.Abstractions.csproj
@@ -6,6 +6,8 @@
     <Product>Otc.PubSub</Product>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-pubsub</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/OleConsignado/otc-pubsub/blob/master/LICENSE</PackageLicenseUrl>
+    <Version>2.1.0</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/Otc.PubSub.Kafka.Tests/IntegrationTests.cs
+++ b/Source/Otc.PubSub.Kafka.Tests/IntegrationTests.cs
@@ -22,7 +22,8 @@ namespace Otc_PubSub.Kafka.Tests
             {
                 config.Configure(new KafkaPubSubConfiguration()
                 {
-                    BrokerList = "192.168.145.100"
+                    BrokerList = "192.168.145.100",
+                    AutoOffsetReset = "latest"
                 });
             });
 

--- a/Source/Otc.PubSub.Kafka/KafkaPubSubConfiguration.cs
+++ b/Source/Otc.PubSub.Kafka/KafkaPubSubConfiguration.cs
@@ -6,5 +6,7 @@ namespace Otc.PubSub.Kafka
     {
         [Required]
         public string BrokerList { get; set; }
+        [Required]
+        public string AutoOffsetReset { get; set; } = "latest";
     }
 }

--- a/Source/Otc.PubSub.Kafka/KafkaPubSubConfigurationExtensions.cs
+++ b/Source/Otc.PubSub.Kafka/KafkaPubSubConfigurationExtensions.cs
@@ -19,7 +19,7 @@ namespace Otc.PubSub.Kafka
                 { "group.id", groupId },
                 { "enable.auto.commit", false },
                 { "bootstrap.servers", configuration.BrokerList },
-                { "auto.offset.reset", "earliest" }
+                { "auto.offset.reset", configuration.AutoOffsetReset }
             };
         }
     }

--- a/Source/Otc.PubSub.Kafka/Otc.PubSub.Kafka.csproj
+++ b/Source/Otc.PubSub.Kafka/Otc.PubSub.Kafka.csproj
@@ -6,6 +6,8 @@
     <Product>Otc.PubSub</Product>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-pubsub</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/OleConsignado/otc-pubsub/blob/master/LICENSE</PackageLicenseUrl>
+    <Version>2.1.0</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Implementando a propriedade AutoOffsetReset em KafkaPubSubConfiguration para controle do tipo de leitura do consumidor kafka quando ocorre um reset/retomada. 

earlist: estava fixo no código e corresponde a retomar da mensagem mais antiga no offset 
latest: está configurado como default, mas o consumidor poderá controlar por variável de ambiente e o comportamento consiste em retomar da mensagem mais recente do offset.

New version of Otc.PubSub.Kafka: 2.1.0